### PR TITLE
Upgrade grafana to v7.3.9 in test

### DIFF
--- a/test/grafana/config.yaml
+++ b/test/grafana/config.yaml
@@ -1,4 +1,4 @@
 app:
   namespace: grafana
   source: oci://registry.local.com/sara/grafana
-  version: 8.4.7
+  version: 7.3.9


### PR DESCRIPTION
Upgrade grafana to v7.3.9

PR URL: https://github.com/sarataha/charts/pull/37