### PR TITLE
Upgrade grafana to v7.3.2 in test

### DIFF
--- a/test/grafana/config.yaml
+++ b/test/grafana/config.yaml
@@ -1,4 +1,4 @@
 app:
   namespace: grafana
   source: oci://registry.local.com/sara/grafana
-  version: 7.3.1
+  version: 7.3.2


### PR DESCRIPTION
Upgrade grafana to v7.3.2

PR URL: https://github.com/sarataha/charts/pull/61